### PR TITLE
Trim out more unnecessary Z3 model expressions, add test cases

### DIFF
--- a/EtumrepMMO.ConsoleApp/Program.cs
+++ b/EtumrepMMO.ConsoleApp/Program.cs
@@ -1,7 +1,7 @@
 ﻿using EtumrepMMO.Lib;
 
 const string entityFolderName = "mons";
-var result = GroupSeedFinder.FindSeeds(entityFolderName).FirstOrDefault();
+var result = GroupSeedFinder.FindSeed(entityFolderName);
 if (result is default(ulong))
 {
     Console.WriteLine("No group seeds found with the input data. Double check your inputs.");

--- a/EtumrepMMO.Lib/GroupSeedFinder.cs
+++ b/EtumrepMMO.Lib/GroupSeedFinder.cs
@@ -6,16 +6,16 @@ public static class GroupSeedFinder
 {
     public const byte max_rolls = 32;
 
-    public static IEnumerable<ulong> FindSeeds(string folder, byte maxRolls = max_rolls) => FindSeeds(Directory.EnumerateFiles(folder), maxRolls);
-    public static IEnumerable<ulong> FindSeeds(IEnumerable<string> files, byte maxRolls = max_rolls) => FindSeeds(files.Select(File.ReadAllBytes), maxRolls);
-    public static IEnumerable<ulong> FindSeeds(IEnumerable<byte[]> data, byte maxRolls = max_rolls) => FindSeeds(data.Select(PKMConverter.GetPKMfromBytes).OfType<PKM>(), maxRolls);
+    public static ulong FindSeed(string folder, byte maxRolls = max_rolls) => FindSeed(Directory.EnumerateFiles(folder), maxRolls);
+    public static ulong FindSeed(IEnumerable<string> files, byte maxRolls = max_rolls) => FindSeed(files.Select(File.ReadAllBytes), maxRolls);
+    public static ulong FindSeed(IEnumerable<byte[]> data, byte maxRolls = max_rolls) => FindSeed(data.Select(PKMConverter.GetPKMfromBytes).OfType<PKM>(), maxRolls);
 
     /// <summary>
     /// Returns all valid Group Seeds (should only be one) that generated the input data.
     /// </summary>
     /// <param name="data">Entities that were generated</param>
     /// <param name="maxRolls">Max amount of PID re-rolls for shiny odds.</param>
-    public static IEnumerable<ulong> FindSeeds(IEnumerable<PKM> data, byte maxRolls = max_rolls)
+    public static ulong FindSeed(IEnumerable<PKM> data, byte maxRolls = max_rolls)
     {
         var entities = data.ToArray();
         var ecs = entities.Select(z => z.EncryptionConstant).ToArray();
@@ -25,8 +25,6 @@ public static class GroupSeedFinder
         {
             var entity = entities[i];
             Console.WriteLine($"Checking entity {i+1}/{entities.Length} for group seeds...");
-            int count = 0;
-
             var pokeResult = IterativeReversal.GetSeeds(entity, maxRolls);
 
             foreach (var (pokeSeed, rolls) in pokeResult)
@@ -41,12 +39,11 @@ public static class GroupSeedFinder
                         continue;
 
                     Console.WriteLine($"Found a group seed with PID roll count = {rolls}");
-                    count++;
-                    yield return groupSeed;
+                    return groupSeed;
                 }
             }
-            Console.WriteLine($"Found {count} group seeds for entity {i+1}.");
         }
+        return default;
     }
 
     /// <summary>

--- a/EtumrepMMO.Lib/ReversalMethods/GenSeedReversal.cs
+++ b/EtumrepMMO.Lib/ReversalMethods/GenSeedReversal.cs
@@ -8,57 +8,49 @@ namespace EtumrepMMO.Lib;
 /// </summary>
 public static class GenSeedReversal
 {
+    private static readonly Context ctx = new(new Dictionary<string, string> { { "model", "true" } });
+
     /// <summary>
     /// Middle level seed calculation for the Generator Seed
     /// </summary>
     /// <param name="seed">Bottom level Entity seed.</param>
     public static IEnumerable<ulong> FindPotentialGenSeeds(ulong seed)
     {
-        using var ctx = new Context(new Dictionary<string, string> { { "model", "true" } });
-        var exp = CreateGenSeedModel(ctx, seed, out var s0);
+        var exp = CreateGenSeedModel(seed);
+        if (Check(exp) is not { } m)
+            throw new ArgumentException("Unable to solve expression.");
 
-        return FindAllMatches(ctx, exp, s0);
-    }
-
-    private static IEnumerable<ulong> FindAllMatches(Context ctx, BoolExpr exp, BitVecExpr s0)
-    {
-        while (Check(ctx, exp) is { } m)
+        foreach (var kvp in m.Consts)
         {
-            foreach (var kvp in m.Consts)
-            {
-                var tmp = (BitVecNum)kvp.Value;
-                yield return tmp.UInt64;
-                exp = ctx.MkAnd(exp, ctx.MkNot(ctx.MkEq(s0, m.Evaluate(s0))));
-            }
+            var tmp = (BitVecNum)kvp.Value;
+            yield return tmp.UInt64;
         }
     }
 
-    private static BoolExpr CreateGenSeedModel(Context ctx, ulong seed, out BitVecExpr s0)
+    private static readonly BitVecExpr GenSeedExpression = GetBaseGenSeedModel();
+
+    private static BoolExpr CreateGenSeedModel(ulong seed)
     {
-        s0 = ctx.MkBVConst("s0", 64);
-        BitVecExpr s1 = ctx.MkBV(Xoroshiro128Plus.XOROSHIRO_CONST, 64);
-
         var real_seed = ctx.MkBV(seed, 64);
-
-        AdvanceSymbolicNext(ctx, ref s0, ref s1); // slot
-        var genseed_check = AdvanceSymbolicNext(ctx, ref s0, ref s1); // genseed
-
-        return ctx.MkEq(real_seed, genseed_check);
+        return ctx.MkEq(real_seed, GenSeedExpression);
     }
 
-    private static BitVecExpr AdvanceSymbolicNext(Context ctx, ref BitVecExpr s0, ref BitVecExpr s1)
+    private static BitVecExpr GetBaseGenSeedModel()
     {
-        var and_val = ctx.MkBV(0xFFFFFFFFFFFFFFFF, 64);
-        var res = ctx.MkBVAND(ctx.MkBVAdd(s0, s1), and_val);
+        BitVecExpr s0 = ctx.MkBVConst("s0", 64);
+        BitVecExpr s1 = ctx.MkBV(Xoroshiro128Plus.XOROSHIRO_CONST, 64);
+
+        // var slotRand = ctx.MkBVAdd(s0, s1);
         s1 = ctx.MkBVXOR(s0, s1);
         var tmp = ctx.MkBVRotateLeft(24, s0);
         var tmp2 = ctx.MkBV(1 << 16, 64);
         s0 = ctx.MkBVXOR(tmp, ctx.MkBVXOR(s1, ctx.MkBVMul(s1, tmp2)));
         s1 = ctx.MkBVRotateLeft(37, s1);
-        return res;
+        return ctx.MkBVAdd(s0, s1); // genseed
+        // no rot/xor needed, the add result is enough.
     }
 
-    private static Model? Check(Context ctx, BoolExpr cond)
+    private static Model? Check(BoolExpr cond)
     {
         Solver solver = ctx.MkSolver();
         solver.Assert(cond);

--- a/EtumrepMMO.Tests/ReversalTests.cs
+++ b/EtumrepMMO.Tests/ReversalTests.cs
@@ -24,9 +24,8 @@ public class ReversalTests
             seeds.Should().NotBeEmpty();
         }
 
-        var groupSeed = GroupSeedFinder.FindSeeds(all, rollCount);
-        var results = groupSeed.ToArray();
-        results.Length.Should().Be(1);
+        var groupSeed = GroupSeedFinder.FindSeed(all, rollCount);
+        groupSeed.Should().NotBe(default);
     }
 
     [Theory]
@@ -41,5 +40,18 @@ public class ReversalTests
         s0.Should().Be(seedGroup);
 
         GroupSeedReversal.GetGroupSeed(seedGen).Should().Be(seedGroup);
+    }
+
+    [Theory]
+    [InlineData(0xad819080a1effcf6, 0xfcca2321c7d655ed)]
+    public void ReverseStep2(ulong seedGen, ulong seedPoke)
+    {
+        var xoro = new Xoroshiro128Plus(seedGen);
+        _ = xoro.Next(); // slot
+        var expectPoke = xoro.Next();
+        expectPoke.Should().Be(seedPoke);
+
+        var reversal = GenSeedReversal.FindPotentialGenSeeds(seedPoke);
+        reversal.Single().Should().Be(seedGen);
     }
 }

--- a/EtumrepMMO.Tests/ReversalTests.cs
+++ b/EtumrepMMO.Tests/ReversalTests.cs
@@ -43,6 +43,7 @@ public class ReversalTests
     }
 
     [Theory]
+    [InlineData(5, new ulong[] { })]
     [InlineData(0xfcca2321c7d655ed, new[] { 0xad819080a1effcf6u })]
     [InlineData(0x366a1a7ed65e146c, new[] { 0x041b4ef9172f53f3u, 0xd9d1e54df50036ecu })]
     [InlineData(0xa69d3c25666a8c6a, new[] { 0x323ff4f71fb9898cu, 0x3d8d7e995f7569feu, 0x0eec4cffd2595d1bu })]
@@ -57,6 +58,11 @@ public class ReversalTests
         }
 
         var reversal = GenSeedReversal.FindPotentialGenSeeds(seedPoke).ToArray();
+        if (seedGenPossible.Length == 0)
+        {
+            reversal.Length.Should().Be(0);
+            return;
+        }
 
         // check for sequence equality, any order
         seedGenPossible.Should().Contain(reversal);

--- a/EtumrepMMO.Tests/ReversalTests.cs
+++ b/EtumrepMMO.Tests/ReversalTests.cs
@@ -43,15 +43,23 @@ public class ReversalTests
     }
 
     [Theory]
-    [InlineData(0xad819080a1effcf6, 0xfcca2321c7d655ed)]
-    public void ReverseStep2(ulong seedGen, ulong seedPoke)
+    [InlineData(0xfcca2321c7d655ed, new[] { 0xad819080a1effcf6u })]
+    [InlineData(0x366a1a7ed65e146c, new[] { 0x041b4ef9172f53f3u, 0xd9d1e54df50036ecu })]
+    [InlineData(0xa69d3c25666a8c6a, new[] { 0x323ff4f71fb9898cu, 0x3d8d7e995f7569feu, 0x0eec4cffd2595d1bu })]
+    public void ReverseStep2(ulong seedPoke, ulong[] seedGenPossible)
     {
-        var xoro = new Xoroshiro128Plus(seedGen);
-        _ = xoro.Next(); // slot
-        var expectPoke = xoro.Next();
-        expectPoke.Should().Be(seedPoke);
+        foreach (var seedGen in seedGenPossible)
+        {
+            var xoro = new Xoroshiro128Plus(seedGen);
+            _ = xoro.Next(); // slot
+            var expectPoke = xoro.Next();
+            expectPoke.Should().Be(seedPoke);
+        }
 
-        var reversal = GenSeedReversal.FindPotentialGenSeeds(seedPoke);
-        reversal.Single().Should().Be(seedGen);
+        var reversal = GenSeedReversal.FindPotentialGenSeeds(seedPoke).ToArray();
+
+        // check for sequence equality, any order
+        seedGenPossible.Should().Contain(reversal);
+        reversal.Should().Contain(seedGenPossible);
     }
 }


### PR DESCRIPTION
* Changes the group seed finder to only yield the first result -- won't ever happen.
* Adds test cases for Z3 to ensure that all possible genseed<-pkm results are yielded (if any).
* Removes unnecessary expression chaining in the Z3 model building, saves most of the expression for each attempt.
^ s0 now checks the const instead of the compound expression, and removed bitwise and `ulong.MaxValue` (unnecessary step from python port).